### PR TITLE
docs: update rpc docs to reflect current transport

### DIFF
--- a/docs/rpc/rpc-message.md
+++ b/docs/rpc/rpc-message.md
@@ -10,7 +10,7 @@ frontend and backend.  The canonical model lives on the backend in
 | Model | Purpose |
 | ----- | ------- |
 | `Gen` | Wraps the connection generation (`num`, `salt`) assigned by the server. It is embedded in every RPC envelope so both sides can detect stale traffic.【F:backend/rpc/models.py†L12-L20】 |
-| `Route` | Points a message to either a capability (`capability`) or an object (`object`). The backend infers the default lane from these values when the explicit `lane` is missing.【F:backend/rpc/models.py†L24-L77】 |
+| `Route` | Points a message to either a capability (`capability`) or an object (`object`). The backend infers the default lane from these values when the explicit `lane` is missing.【F:backend/rpc/models.py†L24-L27】 |
 | `RPCMessage` | The wire envelope for all RPC communication, enforcing camelCase aliases, forbidding extra fields, and performing lane inference via a model validator.【F:backend/rpc/models.py†L31-L79】 |
 
 ## Envelope fields
@@ -21,13 +21,13 @@ otherwise, the field is optional and defaults to `null`/`None`.
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `v` | `str` | Schema version (`"0.1"`).【F:backend/rpc/models.py†L39-L40】 |
-| `id` | `str` | UUIDv7 that uniquely identifies the message.【F:backend/rpc/models.py†L40】 |
-| `type` | enum | Message category. Valid values include control (`hello`, `welcome`, `clientReady`, `heartbeat`, `ack`) and workload messages (`request`, `emit`, `reply`, `subscribe`, `stateUpdate`, `unsubscribe`, `cancel`, `error`).【F:backend/rpc/models.py†L41-L57】【F:frontend/assets/types.d.ts†L4-L36】 |
+| `id` | `str` | UUIDv7 that uniquely identifies the message.【F:backend/rpc/models.py†L39-L40】 |
+| `type` | enum | Message category. Valid values include control (`hello`, `welcome`, `clientReady`, `heartbeat`, `ack`) and workload messages (`request`, `emit`, `reply`, `subscribe`, `stateUpdate`, `unsubscribe`, `cancel`, `error`).【F:backend/rpc/models.py†L39-L57】【F:frontend/assets/rpc-client.js†L913-L1052】 |
 | `correlatesTo` | `str` | Links to the parent message (e.g., replies, ACKs, cancels).【F:backend/rpc/models.py†L42】 |
 | `gen` | `Gen` | Server-assigned generation, echoed by the client to validate session continuity.【F:backend/rpc/models.py†L43】 |
 | `ts` | `int` | Monotonic send timestamp populated on creation.【F:backend/rpc/models.py†L44】 |
-| `lane` | `str` | Delivery lane. Defaults to `"sys"` for control traffic; otherwise inferred from `route` (`cap:<capability>` / `obj:<id>`) when empty.【F:backend/rpc/models.py†L59-L77】【F:backend/rpc/messages.py†L39-L67】【F:frontend/assets/rpc-client.js†L1075-L1094】 |
-| `budgetMs` | `int` | Optional time budget for the operation. Builders pick defaults from protocol settings and priority classes.【F:backend/rpc/models.py†L45】【F:backend/rpc/messages.py†L39-L67】【F:frontend/assets/rpc-client.js†L952-L999】【F:frontend/assets/rpc-client.js†L1192-L1199】 |
+| `lane` | `str` | Delivery lane. Defaults to `"sys"` for control traffic; otherwise inferred from `route` (`cap:<capability>` / `obj:<id>`) when empty.【F:backend/rpc/models.py†L59-L77】【F:backend/rpc/messages.py†L37-L71】【F:frontend/assets/rpc-client.js†L1075-L1095】 |
+| `budgetMs` | `int` | Optional time budget for the operation. Builders pick defaults from protocol settings and priority classes.【F:backend/rpc/models.py†L45】【F:backend/rpc/messages.py†L37-L71】【F:frontend/assets/rpc-client.js†L952-L999】【F:frontend/assets/rpc-client.js†L1191-L1199】 |
 | `ackOf` | `int` | Reserved for richer ACK semantics; currently unused but part of the schema.【F:backend/rpc/models.py†L46】 |
 | `job` | `dict` | Mirrors backend job progress snapshots when long-running work reports state.【F:backend/rpc/models.py†L47】 |
 | `idempotencyKey` | `str` | Enables backend deduplication and cached replies; defaults to the message ID for request/emit messages.【F:backend/rpc/models.py†L48】【F:frontend/assets/rpc-client.js†L952-L990】 |
@@ -39,22 +39,22 @@ otherwise, the field is optional and defaults to `null`/`None`.
 | `origin` | `dict` | Metadata (e.g., tracing) passed through without affecting permissions.【F:backend/rpc/models.py†L54】 |
 | `chunkNo` | `int` | Index of the chunk when streaming payloads.【F:backend/rpc/models.py†L55】 |
 | `final` | `int`/`bool` | Marks the final chunk in a stream.【F:backend/rpc/models.py†L56】 |
-| `payload` | `dict` | Application data. Helpers enforce payload shapes (e.g., replies require a payload).【F:backend/rpc/models.py†L57】【F:backend/rpc/messages.py†L71-L121】 |
+| `payload` | `dict` | Application data. Helpers enforce payload shapes (e.g., replies require a payload).【F:backend/rpc/models.py†L57】【F:backend/rpc/messages.py†L75-L146】 |
 
 ### Helper constructors
 
 Backend helper functions construct validated envelopes while enforcing required
 fields, correlating IDs, and copying idempotency keys from the triggering
-message.【F:backend/rpc/messages.py†L33-L121】  The frontend mirrors these helpers in
+message.【F:backend/rpc/messages.py†L37-L146】  The frontend mirrors these helpers in
 `RpcClient`, guaranteeing symmetric message shapes during creation of hello,
 request, emit, subscribe, cancel, unsubscribe, reply, stateUpdate, error, and
-ack messages.【F:frontend/assets/rpc-client.js†L873-L1200】  Both sides rely on the
+ack messages.【F:frontend/assets/rpc-client.js†L849-L1110】  Both sides rely on the
 shared defaults for schema version, system lane, and acknowledgment budget.
 
 ### Serialization and logging
 
 `sendRPCMessage` serializes models via `safeJsonDumps`, which dumps the Pydantic
 model using deterministic JSON separators before transmitting it over the
-WebSocket and handing the payload to the RPC logging filter.【F:backend/rpc/transport.py†L28-L43】【F:backend/core/jsonutils.py†L18-L45】  The frontend performs the
+WebSocket and handing the payload to the RPC logging filter.【F:backend/rpc/transport.py†L52-L69】【F:backend/core/jsonutils.py†L18-L45】  The frontend performs the
 reverse operation: incoming JSON is parsed to plain objects and optionally logged
 for debugging.【F:frontend/assets/rpc-client.js†L474-L505】【F:frontend/assets/rpc-client.js†L767-L784】

--- a/docs/rpc/websocket-flow.md
+++ b/docs/rpc/websocket-flow.md
@@ -12,12 +12,12 @@ hydrate runtime configuration and establish identity:
 
 1. **Settings fetch** – `/settings` returns the merged server configuration.
    The bootstrap script freezes it onto `globalThis.Turnix` so early modules can
-   read feature flags and other environment switches before RPC is ready.【F:frontend/bootstrap.js†L37-L88】【F:backend/app/web.py†L13-L18】
+   read feature flags and other environment switches before RPC is ready.【F:frontend/bootstrap.js†L37-L88】【F:backend/app/web.py†L14-L17】
 2. **View bootstrap** – `/api/bootstrap` issues or refreshes a `clientId`
    cookie, binds it to a view, and returns the `viewId`, `viewToken`, and the
    server's current generation number.  The frontend includes these fields in
    the subsequent `hello` payload along with a per-tab `clientInstanceId` and
-   the last persisted generation so reconnects can resume cleanly.【F:frontend/bootstrap.js†L40-L84】【F:backend/api/bootstrap.py†L16-L61】【F:frontend/bootstrap.js†L61-L83】
+   the last persisted generation so reconnects can resume cleanly.【F:frontend/bootstrap.js†L40-L84】【F:backend/api/bootstrap.py†L16-L84】【F:frontend/bootstrap.js†L61-L83】
 
 The generated `viewToken` is cached server-side by `ViewRegistry`, ensuring only
 the authenticated client can bind to that view during the WebSocket handshake.
@@ -30,33 +30,33 @@ their shared `clientId` while minting distinct tokens for each tab.【F:backend/
    `ws(s)://…/ws`.  The backend registers this endpoint via
    `mountWebSocket`.  After accepting the socket it enters a receive loop that
    filters out non-text frames and guards against oversized payloads before
-   attempting to validate them as `RPCMessage` instances.【F:backend/rpc/transport.py†L67-L115】
+   attempting to validate them as `RPCMessage` instances.【F:backend/rpc/transport.py†L105-L167】
 2. **Client hello** – Immediately after `WebSocket.OPEN`, the frontend sends a
    hello frame containing optional view metadata.  The helper enforces the
    standard schema version, `sys` lane, and placeholder generation.【F:frontend/assets/rpc-client.js†L356-L374】【F:frontend/assets/rpc-client.js†L908-L926】
 3. **Welcome** – On the first valid `hello`, the server resolves or creates a
    view, binds the WebSocket to that view, allocates a new generation via
-   `RPCSession.newGeneration`, patches view state, and returns a `welcome`
-   message that carries the generation and a snapshot of the current state.【F:backend/rpc/transport.py†L120-L160】【F:backend/rpc/session.py†L12-L41】
+   `RPCConnection.newGeneration`, patches view state, and returns a `welcome`
+   message that carries the generation and a snapshot of the current state.【F:backend/rpc/transport.py†L171-L230】【F:backend/rpc/connection.py†L21-L43】
 4. **Client ready** – After the welcome arrives the browser marks the connection
    as ready, flushes queued messages, and resumes subscriptions.  It can then
    report module load status via `clientReady`, which the backend acknowledges
    while recording module metadata and preventing duplicate processing per
-   generation.【F:frontend/assets/rpc-client.js†L474-L522】【F:frontend/assets/rpc-client.js†L450-L466】【F:backend/rpc/transport.py†L174-L236】
+   generation.【F:frontend/assets/rpc-client.js†L474-L522】【F:frontend/assets/rpc-client.js†L450-L466】【F:backend/rpc/transport.py†L244-L319】
 5. **Heartbeat** – Both sides maintain liveness.  The client periodically sends
    `heartbeat` frames; the server updates its timestamp and ACKs them.  Missed
-   heartbeats trigger reconnection logic in the browser.【F:backend/rpc/transport.py†L242-L245】【F:frontend/assets/rpc-client.js†L1099-L1126】
+   heartbeats trigger reconnection logic in the browser.【F:backend/rpc/transport.py†L321-L328】【F:frontend/assets/rpc-client.js†L1099-L1126】
 6. **Disconnect** – When the socket closes, outstanding request and subscription
    tasks are cancelled on the server, the view binding is removed, and the socket
    is closed.  The client tears down timers, rejects pending promises, and
-   schedules exponential backoff reconnect attempts.【F:backend/rpc/transport.py†L323-L337】【F:frontend/assets/rpc-client.js†L376-L403】
+   schedules exponential backoff reconnect attempts.【F:backend/rpc/transport.py†L605-L646】【F:frontend/assets/rpc-client.js†L376-L403】
 
 ## Session and generation tracking
 
-`RPCSession` tracks per-view/client state: idempotency cache, pending tasks,
+`RPCConnection` tracks per-view/client state: idempotency cache, pending tasks,
 subscription coroutines, and generation metadata.  Each successful `hello`
 bumps the generation counter and salt, ensuring replayed messages from older
-sessions can be ignored.【F:backend/rpc/session.py†L12-L60】  The frontend stores the
+sessions can be ignored.【F:backend/rpc/connection.py†L21-L60】  The frontend stores the
 most recent generation and discards any message that does not match it.【F:frontend/assets/rpc-client.js†L489-L527】
 
 ## Message dispatch
@@ -67,42 +67,42 @@ message and dispatches based on the `type` and `route`:
 - **Requests** – Routed either to object handlers or capability-based request
   handlers.  The transport checks permissions through `_ensureCapabilityOrError`
   before invoking the registered handler.  Errors are wrapped in `error`
-  envelopes tied to the triggering message.【F:backend/rpc/transport.py†L238-L321】【F:backend/rpc/transport.py†L47-L64】【F:backend/rpc/messages.py†L71-L121】
+  envelopes tied to the triggering message.【F:backend/rpc/transport.py†L330-L604】【F:backend/rpc/transport.py†L85-L101】【F:backend/rpc/messages.py†L55-L146】
 - **Emits and subscribes** – Resolved against capability-specific handlers.
   Subscribes are tracked so later `cancel` / `unsubscribe` messages can stop the
-  running task and drop chat subscriptions.【F:backend/rpc/transport.py†L247-L321】
+  running task and drop chat subscriptions.【F:backend/rpc/transport.py†L366-L603】
 - **Cancels** – Remove pending work and cancel live subscriptions, cleaning up
-  session-side tracking structures.【F:backend/rpc/transport.py†L247-L263】
+  session-side tracking structures.【F:backend/rpc/transport.py†L330-L364】
 
 On the browser, incoming workload messages targeting exposed capabilities are
 ACKed automatically, then routed to the registered `call`, `emit`, or
 `subscribe` handler.  Replies and errors resolve or reject pending promises,
-while subscription updates trigger local event emitters.【F:frontend/assets/rpc-client.js†L529-L700】
+while subscription updates trigger local event emitters.【F:frontend/assets/rpc-client.js†L529-L665】
 
 ## Acknowledgements and flow control
 
 - **Automatic ACKs** – The backend ACKs every message other than `ack` and
   `heartbeat`, and the frontend mirrors this rule for all messages except the
   handshake/control set.  Both sides use helper constructors to tie the ACK to
-  the original message ID and to place it on the `sys` lane.【F:backend/rpc/transport.py†L238-L245】【F:frontend/assets/rpc-client.js†L645-L824】【F:backend/rpc/messages.py†L51-L67】
+  the original message ID and to place it on the `sys` lane.【F:backend/rpc/transport.py†L321-L348】【F:frontend/assets/rpc-client.js†L645-L653】【F:backend/rpc/messages.py†L55-L71】
 - **Budget and retry windows** – Request and emit helpers populate `budgetMs`
   from timeout classes.  The browser keeps per-lane in-flight counters and
   queues additional work until ACKs or replies arrive, preventing overload while
   providing best-effort cancellation on timeout.【F:frontend/assets/rpc-client.js†L952-L999】【F:frontend/assets/rpc-client.js†L703-L765】【F:frontend/assets/rpc-client.js†L1146-L1194】
 - **Idempotency** – Client helpers copy an `idempotencyKey` for request/emit
-  messages.  The server session caches IDs and previous replies so repeated
-  invocations can be deduplicated.【F:frontend/assets/rpc-client.js†L952-L990】【F:backend/rpc/session.py†L17-L60】
+  messages.  The server connection caches IDs and previous replies so repeated
+  invocations can be deduplicated.【F:frontend/assets/rpc-client.js†L952-L990】【F:backend/rpc/connection.py†L21-L68】
 
 ## Permissions and principals
 
 Before invoking capability handlers the backend derives the principal from the
 message and validates that it has the required capability.  Permission failures
 are converted into structured `error` messages containing retry metadata, so the
-client can surface clean feedback.【F:backend/rpc/transport.py†L47-L64】
+client can surface clean feedback.【F:backend/rpc/transport.py†L85-L101】
 
 ## Logging and observability
 
 Each outbound frame is serialized via `safeJsonDumps` and passed through the RPC
 logging decision engine, enabling centrally controlled logging on both sides of
 the connection.  The browser offers matching logging hooks that honor the same
-filters to keep debugging consistent.【F:backend/rpc/transport.py†L28-L43】【F:frontend/assets/rpc-client.js†L767-L784】
+filters to keep debugging consistent.【F:backend/rpc/transport.py†L52-L69】【F:frontend/assets/rpc-client.js†L767-L784】


### PR DESCRIPTION
## Summary
- update the RPC message reference to cite the current backend models and frontend helpers, including refreshed serialization references
- refresh the websocket flow guide so it refers to `RPCConnection`, the latest transport line numbers, and the current bootstrap/handshake lifecycle

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bf3053ccc8333990e5b92ed97a8a2)